### PR TITLE
Fix for 412 errors occurring during Download-Upload

### DIFF
--- a/src/IndexedBlobStore.Tests/ReliableOperationTests.cs
+++ b/src/IndexedBlobStore.Tests/ReliableOperationTests.cs
@@ -7,7 +7,7 @@ namespace IndexedBlobStore.Tests
     public class when_blob_upload_fails_with_bad_request
     {
         Establish context = () => _uploadAttempts = 0;
-        Because of = () => _exception = Catch.Exception(() =>  ReliableCloudOperations.UploadBlob(() =>
+        Because of = () => _exception = Catch.Exception(() =>  ReliableCloudOperations.Retry(() =>
         {
             _uploadAttempts++;
             throw new StorageException(new RequestResult { HttpStatusCode = 400 }, "request bad", new Exception("inside you"));
@@ -23,7 +23,7 @@ namespace IndexedBlobStore.Tests
     public class when_blob_upload_fails_with_precondition_failed
     {
         Establish context = () => _uploadAttempts = 0;
-        Because of = () => _exception = Catch.Exception(() => ReliableCloudOperations.UploadBlob(() =>
+        Because of = () => _exception = Catch.Exception(() => ReliableCloudOperations.Retry(() =>
         {
             _uploadAttempts++;
             throw new StorageException(new RequestResult { HttpStatusCode = 412 }, "preconditions not met", new Exception("inside you"));
@@ -38,7 +38,7 @@ namespace IndexedBlobStore.Tests
 
     public class when_operation_has_some_other_storage_exception
     {
-        Because of = () => _exception = Catch.Exception(() => ReliableCloudOperations.UploadBlob(() =>
+        Because of = () => _exception = Catch.Exception(() => ReliableCloudOperations.Retry(() =>
         {
             throw new StorageException(new RequestResult { HttpStatusCode = 500 }, "internal", new Exception("inside you"));
         }));
@@ -51,7 +51,7 @@ namespace IndexedBlobStore.Tests
     {
         Establish context = () => _uploadAttempts = 0;
 
-        Because of = () => ReliableCloudOperations.UploadBlob(() => _uploadAttempts++);
+        Because of = () => ReliableCloudOperations.Retry(() => _uploadAttempts++);
 
         It should_not_retry = () => _uploadAttempts.ShouldEqual(1);
 

--- a/src/IndexedBlobStore.Tests/ReliableOperationTests.cs
+++ b/src/IndexedBlobStore.Tests/ReliableOperationTests.cs
@@ -20,6 +20,22 @@ namespace IndexedBlobStore.Tests
         static Exception _exception;
     }
 
+    public class when_blob_upload_fails_with_precondition_failed
+    {
+        Establish context = () => _uploadAttempts = 0;
+        Because of = () => _exception = Catch.Exception(() => ReliableCloudOperations.UploadBlob(() =>
+        {
+            _uploadAttempts++;
+            throw new StorageException(new RequestResult { HttpStatusCode = 412 }, "preconditions not met", new Exception("inside you"));
+        }));
+
+        It should_NOT_retry = () => _uploadAttempts.ShouldEqual(1);
+        It should_throw_the_exception = () => _exception.ShouldNotBeNull();
+
+        static int _uploadAttempts;
+        static Exception _exception;
+    }
+
     public class when_operation_has_some_other_storage_exception
     {
         Because of = () => _exception = Catch.Exception(() => ReliableCloudOperations.UploadBlob(() =>

--- a/src/IndexedBlobStore.Tests/UploadingBlobs.cs
+++ b/src/IndexedBlobStore.Tests/UploadingBlobs.cs
@@ -181,5 +181,4 @@ namespace IndexedBlobStore.Tests
         static Stream _contentsStream;
         static string _contents;
     }
-
 }

--- a/src/IndexedBlobStore.Tests/UploadingBlobs.cs
+++ b/src/IndexedBlobStore.Tests/UploadingBlobs.cs
@@ -87,6 +87,27 @@ namespace IndexedBlobStore.Tests
         static string _content = "when uploading blob that already exists";
     }
 
+    public class when_uploading_blob_that_already_exists_interleaved : IndexedBlobStoreTest
+    {
+        Because of = () => _exception = Catch.Exception(() =>
+        {
+            _reference = Client.CreateIndexedBlob("file", CreateStream(_content));
+
+            using (var blob = Client.CreateIndexedBlob("file", CreateStream(_content)))
+            {
+                blob.Upload();
+            }
+
+            _reference.Upload();
+        });
+        It should_indicate_it_already_exists = () => _reference.Exists.ShouldBeTrue();
+        It should_throw_blob_already_exists_exception_if_uploaded = () => _exception.ShouldBeOfExactType<BlobAlreadyExistsException>();
+
+        static Exception _exception;
+        static IIndexedBlob _reference;
+        static string _content = "when uploading blob that already exists interleaved";
+    }
+
     public class when_uploading_blob_using_custom_key : IndexedBlobStoreTest
     {
         Because of = () =>

--- a/src/IndexedBlobStore/CloudIndexedBlob.cs
+++ b/src/IndexedBlobStore/CloudIndexedBlob.cs
@@ -127,8 +127,17 @@ namespace IndexedBlobStore
             }
             catch (StorageException storageException)
             {
-                if (storageException.RequestInformation.HttpStatusCode != (int)HttpStatusCode.Conflict)
-                    throw;
+                switch (storageException.RequestInformation.HttpStatusCode)
+                {
+                    case (int)HttpStatusCode.PreconditionFailed:
+                        Exists = true;
+                        throw new BlobAlreadyExistsException(FileKey);
+                    case (int)HttpStatusCode.Conflict:
+                        Exists = true;
+                        throw new BlobAlreadyExistsException(FileKey);
+                }
+
+                throw;
             }
         }
 

--- a/src/IndexedBlobStore/ReliableCloudOperations.cs
+++ b/src/IndexedBlobStore/ReliableCloudOperations.cs
@@ -13,7 +13,7 @@ namespace IndexedBlobStore
 
         public static int RetryCount { get; set; }
 
-        public static void UploadBlob(Action upload)
+        public static void Retry(Action upload)
         {
             var retryCount = 0;
             while (true)

--- a/src/IndexedBlobStore/UploadableIndexedBlob.cs
+++ b/src/IndexedBlobStore/UploadableIndexedBlob.cs
@@ -21,7 +21,7 @@ namespace IndexedBlobStore
         {
             _stream.EnsureAtStart();
             _stream = Store.Cache.Add(FileKey, _stream, Length);
-            ReliableCloudOperations.UploadBlob(() =>
+            ReliableCloudOperations.Retry(() =>
             {
                 _stream.EnsureAtStart();
                 Blob.UploadFromStream(


### PR DESCRIPTION
412 Errors could be thrown if a blob was changed (e.g. it's properties updated) between the OpenRead and the stream.CopyTo methods as the ETag would change and throw a pre-condition failed error.
